### PR TITLE
Add SDL bindings and custom UTF-8 marshaller implementation

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <DefineTrace>true</DefineTrace>
         <DebugType>full</DebugType>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/UnownedUtf8StringMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/UnownedUtf8StringMarshaller.cs
@@ -1,0 +1,59 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Open.CommandAndConquer, Victor Matia <vmatir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the “Software”), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.InteropServices.Marshalling;
+using static Open.CommandAndConquer.Sdl3.SDL3;
+
+namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
+
+[CustomMarshaller(typeof(string), MarshalMode.ManagedToUnmanagedOut, typeof(ManagedToUnmanagedOut))]
+internal static class UnownedUtf8StringMarshaller
+{
+    public unsafe ref struct ManagedToUnmanagedOut
+    {
+        private string? _managed;
+        private byte* _copy;
+
+        public void FromUnmanaged(byte* unmanaged)
+        {
+            if (unmanaged is null)
+            {
+                _managed = null;
+                _copy = null;
+                return;
+            }
+
+            _copy = SDL_strdup(unmanaged);
+            _managed = Utf8StringMarshaller.ConvertToManaged(_copy);
+        }
+
+        public string? ToManaged() => _managed;
+
+        public void Free()
+        {
+            if (_copy is null)
+            {
+                return;
+            }
+
+            SDL_free(_copy);
+            _copy = null;
+        }
+    }
+}

--- a/Open.CommandAndConquer.Sdl3/src/SDL_error.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_error.cs
@@ -1,0 +1,36 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Open.CommandAndConquer, Victor Matia <vmatir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the “Software”), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Open.CommandAndConquer.Sdl3.CustomMarshalling;
+
+namespace Open.CommandAndConquer.Sdl3;
+
+public static partial class SDL3
+{
+    [LibraryImport(
+        nameof(SDL3),
+        EntryPoint = nameof(SDL_GetError),
+        StringMarshalling = StringMarshalling.Custom,
+        StringMarshallingCustomType = typeof(UnownedUtf8StringMarshaller)
+    )]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial string SDL_GetError();
+}

--- a/Open.CommandAndConquer.Sdl3/src/SDL_stdinc.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_stdinc.cs
@@ -1,0 +1,34 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Open.CommandAndConquer, Victor Matia <vmatir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the “Software”), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Open.CommandAndConquer.Sdl3;
+
+public static partial class SDL3
+{
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial byte* SDL_strdup(byte* str);
+
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial void SDL_free(void* str);
+}


### PR DESCRIPTION
Introduced SDL3 bindings, including `SDL_GetError`, `SDL_strdup`, and `SDL_free` functions.

Added a custom marshaller for unmanaged UTF-8 strings to improve interop.

Enabled unsafe code blocks in the project configuration to support pointer operations.