### PR TITLE
Refactor SDL clipboard handling with SafeHandle support.

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -27,7 +27,7 @@
     
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <Title>Open.CommandAndConquer.Sdl3</Title>
         <Authors>Open.CommandAndConquer, Victor Matia &lt;vmatir@outlook.com&gt;</Authors>
         <Description>A direct import of the SDL3 library for the Open.CommandAndConquer project.</Description>

--- a/Open.CommandAndConquer.Sdl3/src/SDL_clipboard.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_clipboard.cs
@@ -26,6 +26,27 @@ namespace Open.CommandAndConquer.Sdl3;
 
 public static partial class SDL3
 {
+    [NativeMarshalling(typeof(SafeHandleMarshaller<SDL_ClipboardData>))]
+    public sealed class SDL_ClipboardData : SafeHandle
+    {
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        public SDL_ClipboardData()
+            : base(invalidHandleValue: IntPtr.Zero, ownsHandle: true) => SetHandle(nint.Zero);
+
+        protected override bool ReleaseHandle()
+        {
+            if (IsInvalid)
+            {
+                return true;
+            }
+
+            SDL_free(handle);
+            SetHandle(IntPtr.Zero);
+            return true;
+        }
+    }
+
     [LibraryImport(
         nameof(SDL3),
         EntryPoint = nameof(SDL_SetClipboardText),
@@ -148,7 +169,7 @@ public static partial class SDL3
         StringMarshalling = StringMarshalling.Utf8
     )]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial IntPtr SDL_GetClipboardData(string mime_type, out CULong size);
+    public static partial SDL_ClipboardData SDL_GetClipboardData(string mime_type, out CULong size);
 
     [LibraryImport(
         nameof(SDL3),

--- a/Open.CommandAndConquer.Sdl3/src/SDL_stdinc.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_stdinc.cs
@@ -34,6 +34,10 @@ public static partial class SDL3
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial void SDL_free(void* str);
 
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SDL_free(IntPtr str);
+
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_fabsf))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial float SDL_fabsf(float f);


### PR DESCRIPTION
Introduced `SDL_ClipboardData` to improve safety using `SafeHandle`, encapsulating clipboard lifecycle management.

Updated `SDL_GetClipboardData` to return the new type and added overload for `SDL_free`.

Bumped project version to 0.8.1.