### PR TITLE
Refactor collections usage and bump version to 0.8.2

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -27,7 +27,7 @@
     
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.8.1</Version>
+        <Version>0.8.2</Version>
         <Title>Open.CommandAndConquer.Sdl3</Title>
         <Authors>Open.CommandAndConquer, Victor Matia &lt;vmatir@outlook.com&gt;</Authors>
         <Description>A direct import of the SDL3 library for the Open.CommandAndConquer project.</Description>

--- a/Open.CommandAndConquer.Sdl3/src/SDL_clipboard.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_clipboard.cs
@@ -119,7 +119,7 @@ public static partial class SDL3
         SDL_ClipboardDataCallback callback,
         SDL_ClipboardCleanupCallback cleanup,
         IntPtr userdata,
-        ICollection<string> mime_types
+        IReadOnlyCollection<string> mime_types
     )
     {
         unsafe

--- a/Open.CommandAndConquer.Sdl3/src/SDL_rect.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_rect.cs
@@ -107,16 +107,13 @@ public static partial class SDL3
         out SDL_Rect result
     );
 
-    public static bool SDL_GetRectEnclosingPoints(
-        ICollection<SDL_Point> points,
-        out SDL_Rect result
-    )
+    public static bool SDL_GetRectEnclosingPoints(Span<SDL_Point> points, out SDL_Rect result)
     {
         unsafe
         {
             return INTERNAL_SDL_GetRectEnclosingPoints(
                 points.ToArray(),
-                points.Count,
+                points.Length,
                 null,
                 out result
             );
@@ -124,7 +121,7 @@ public static partial class SDL3
     }
 
     public static bool SDL_GetRectEnclosingPoints(
-        ICollection<SDL_Point> points,
+        Span<SDL_Point> points,
         SDL_Rect clip,
         out SDL_Rect result
     )
@@ -133,7 +130,7 @@ public static partial class SDL3
         {
             return INTERNAL_SDL_GetRectEnclosingPoints(
                 points.ToArray(),
-                points.Count,
+                points.Length,
                 &clip,
                 out result
             );
@@ -199,7 +196,7 @@ public static partial class SDL3
     );
 
     public static bool SDL_GetRectEnclosingPointsFloat(
-        ICollection<SDL_FPoint> points,
+        Span<SDL_FPoint> points,
         out SDL_FRect result
     )
     {
@@ -207,7 +204,7 @@ public static partial class SDL3
         {
             return INTERNAL_SDL_GetRectEnclosingPointsFloat(
                 points.ToArray(),
-                points.Count,
+                points.Length,
                 null,
                 out result
             );
@@ -215,7 +212,7 @@ public static partial class SDL3
     }
 
     public static bool SDL_GetRectEnclosingPointsFloat(
-        ICollection<SDL_FPoint> points,
+        Span<SDL_FPoint> points,
         SDL_FRect clip,
         out SDL_FRect result
     )
@@ -224,7 +221,7 @@ public static partial class SDL3
         {
             return INTERNAL_SDL_GetRectEnclosingPointsFloat(
                 points.ToArray(),
-                points.Count,
+                points.Length,
                 &clip,
                 out result
             );


### PR DESCRIPTION
Replaced `ICollection` with `IReadOnlyCollection` and `Span` for improved safety and performance in relevant methods.

Updated project version from 0.8.1 to 0.8.2 to reflect these changes.