### PR TITLE
Add operator overloads to SDL_InitFlags and bump version to 0.9.1

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -27,7 +27,7 @@
     
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.9.0</Version>
+        <Version>0.9.1</Version>
         <Title>Open.CommandAndConquer.Sdl3</Title>
         <Authors>Open.CommandAndConquer, Victor Matia &lt;vmatir@outlook.com&gt;</Authors>
         <Description>A direct import of the SDL3 library for the Open.CommandAndConquer project.</Description>

--- a/Open.CommandAndConquer.Sdl3/src/SDL_init.cs
+++ b/Open.CommandAndConquer.Sdl3/src/SDL_init.cs
@@ -30,6 +30,17 @@ public static partial class SDL3
     {
         public static SDL_InitFlags None => new(0U);
 
+        public static SDL_InitFlags operator |(SDL_InitFlags lhs, SDL_InitFlags rhs) =>
+            new(lhs.Value | rhs.Value);
+
+        public static SDL_InitFlags operator &(SDL_InitFlags lhs, SDL_InitFlags rhs) =>
+            new(lhs.Value & rhs.Value);
+
+        public static SDL_InitFlags operator ^(SDL_InitFlags lhs, SDL_InitFlags rhs) =>
+            new(lhs.Value ^ rhs.Value);
+
+        public static SDL_InitFlags operator ~(SDL_InitFlags flags) => new(~flags.Value);
+
         public static implicit operator uint(SDL_InitFlags flags) => flags.Value;
 
         public static implicit operator SDL_InitFlags(uint flags) => new(flags);


### PR DESCRIPTION
Introduced bitwise operator overloads (|, &, ^, ~) for SDL_InitFlags to improve usability and flexibility in flag manipulation.

Updated the project version from 0.9.0 to 0.9.1 to reflect these enhancements.