### PR TITLE
Refactor: Move SDL3 classes to "Imports" namespace

### DIFF
--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/UnownedUtf8StringMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/UnownedUtf8StringMarshaller.cs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Runtime.InteropServices.Marshalling;
-using static Open.CommandAndConquer.Sdl3.SDL3;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
 
 namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
 

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL.cs
@@ -17,31 +17,30 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
-    private const float SDL_FLT_EPSILON = 1.1920928955078125e-07F;
+    private static KeyValuePair<string, bool>[] LibraryNames =>
+        [
+            new("libSDL3.dll", OperatingSystem.IsWindows()),
+            new("libSDL3.so.0", OperatingSystem.IsLinux()),
+        ];
 
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_fabsf))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial float SDL_fabsf(float f);
+    static SDL3() =>
+        NativeLibrary.SetDllImportResolver(
+            typeof(SDL3).Assembly,
+            (name, assembly, path) =>
+                NativeLibrary.Load(
+                    name switch
+                    {
+                        nameof(SDL3) => LibraryNames.FirstOrDefault(pair => pair.Value).Key ?? name,
+                        _ => name,
+                    },
+                    assembly,
+                    path
+                )
+        );
 }

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_blendmode.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_blendmode.cs
@@ -20,9 +20,9 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public record struct SDL_BlendMode(uint Value)
     {

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_clipboard.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_clipboard.cs
@@ -22,9 +22,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     [NativeMarshalling(typeof(SafeHandleMarshaller<SDL_ClipboardData>))]
     public sealed class SDL_ClipboardData : SafeHandle

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_error.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_error.cs
@@ -21,9 +21,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     [LibraryImport(
         nameof(SDL3),

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_init.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_init.cs
@@ -22,9 +22,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public record struct SDL_InitFlags(uint Value)
     {

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_iostream.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_iostream.cs
@@ -22,9 +22,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public enum SDL_IOStatus
     {

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_log.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_log.cs
@@ -21,9 +21,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public enum SDL_LogCategory
     {

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_pixels.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_pixels.cs
@@ -22,9 +22,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public const byte SDL_ALPHA_OPAQUE = 255;
     public const float SDL_ALPHA_OPAQUE_FLOAT = 1F;

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_power.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_power.cs
@@ -17,30 +17,24 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
-    private static KeyValuePair<string, bool>[] LibraryNames =>
-        [
-            new("libSDL3.dll", OperatingSystem.IsWindows()),
-            new("libSDL3.so.0", OperatingSystem.IsLinux()),
-        ];
+    public enum SDL_PowerState
+    {
+        SDL_POWERSTATE_ERROR = -1,
+        SDL_POWERSTATE_UNKNOWN,
+        SDL_POWERSTATE_ON_BATTERY,
+        SDL_POWERSTATE_NO_BATTERY,
+        SDL_POWERSTATE_CHARGING,
+        SDL_POWERSTATE_CHARGED,
+    }
 
-    static SDL3() =>
-        NativeLibrary.SetDllImportResolver(
-            typeof(SDL3).Assembly,
-            (name, assembly, path) =>
-                NativeLibrary.Load(
-                    name switch
-                    {
-                        nameof(SDL3) => LibraryNames.FirstOrDefault(pair => pair.Value).Key ?? name,
-                        _ => name,
-                    },
-                    assembly,
-                    path
-                )
-        );
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetPowerInfo))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial SDL_PowerState SDL_GetPowerInfo(out int seconds, out int percent);
 }

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_properties.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_properties.cs
@@ -22,9 +22,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public record struct SDL_PropertiesID(uint Value)
     {

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_rect.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_rect.cs
@@ -21,9 +21,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     [StructLayout(LayoutKind.Sequential)]
     public struct SDL_Point

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_stdinc.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_stdinc.cs
@@ -20,21 +20,28 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
-    public enum SDL_PowerState
-    {
-        SDL_POWERSTATE_ERROR = -1,
-        SDL_POWERSTATE_UNKNOWN,
-        SDL_POWERSTATE_ON_BATTERY,
-        SDL_POWERSTATE_NO_BATTERY,
-        SDL_POWERSTATE_CHARGING,
-        SDL_POWERSTATE_CHARGED,
-    }
+    private const float SDL_FLT_EPSILON = 1.1920928955078125e-07F;
 
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetPowerInfo))]
+    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
+        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
+
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial SDL_PowerState SDL_GetPowerInfo(out int seconds, out int percent);
+    internal static unsafe partial byte* SDL_strdup(byte* str);
+
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial void SDL_free(void* str);
+
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void SDL_free(IntPtr str);
+
+    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_fabsf))]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial float SDL_fabsf(float f);
 }

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_surface.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_surface.cs
@@ -22,9 +22,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
-namespace Open.CommandAndConquer.Sdl3;
+namespace Open.CommandAndConquer.Sdl3.Imports;
 
-public static partial class SDL3
+internal static partial class SDL3
 {
     public record struct SDL_SurfaceFlags(uint Value)
     {


### PR DESCRIPTION
Updated SDL3 classes to the "Imports" namespace and changed their accessibility from public to internal.

This improves code organization and encapsulation by clearly separating imported functionality.