### PR TITLE
Add blending enums and refactor SDL blend mode handling

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -27,7 +27,7 @@
     
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.9.1</Version>
+        <Version>0.10.0</Version>
         <Title>Open.CommandAndConquer.Sdl3</Title>
         <Authors>Open.CommandAndConquer, Victor Matia &lt;vmatir@outlook.com&gt;</Authors>
         <Description>A direct import of the SDL3 library for the Open.CommandAndConquer project.</Description>

--- a/Open.CommandAndConquer.Sdl3/src/Blending/BlendFactor.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Blending/BlendFactor.cs
@@ -17,22 +17,18 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Open.CommandAndConquer.Sdl3.Blending;
+namespace Open.CommandAndConquer.Sdl3.Blending;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
-
-internal static partial class SDL3
+public enum BlendFactor
 {
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_ComposeCustomBlendMode))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial BlendMode SDL_ComposeCustomBlendMode(
-        BlendFactor srcColorFactor,
-        BlendFactor dstColorFactor,
-        BlendOperation colorOperation,
-        BlendFactor srcAlphaFactor,
-        BlendFactor dstAlphaFactor,
-        BlendOperation alphaOperation
-    );
+    Zero = 1,
+    One,
+    SourceColor,
+    OneMinusSourceColor,
+    SourceAlpha,
+    OneMinusSourceAlpha,
+    DestinationColor,
+    OneMinusDestinationColor,
+    DestinationAlpha,
+    OneMinusDestinationAlpha,
 }

--- a/Open.CommandAndConquer.Sdl3/src/Blending/BlendMode.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Blending/BlendMode.cs
@@ -17,22 +17,15 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Open.CommandAndConquer.Sdl3.Blending;
+namespace Open.CommandAndConquer.Sdl3.Blending;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
-
-internal static partial class SDL3
+public enum BlendMode : uint
 {
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_ComposeCustomBlendMode))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial BlendMode SDL_ComposeCustomBlendMode(
-        BlendFactor srcColorFactor,
-        BlendFactor dstColorFactor,
-        BlendOperation colorOperation,
-        BlendFactor srcAlphaFactor,
-        BlendFactor dstAlphaFactor,
-        BlendOperation alphaOperation
-    );
+    None = 0x00000000U,
+    Alpha = 0x00000001U,
+    Additive = 0x00000002U,
+    ColorModulate = 0x00000004U,
+    ColorMultiply = 0x00000008U,
+    PremultipliedAlpha = 0x00000010U,
+    AdditivePremultiplied = 0x00000020U,
 }

--- a/Open.CommandAndConquer.Sdl3/src/Blending/BlendOperation.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Blending/BlendOperation.cs
@@ -17,22 +17,13 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Open.CommandAndConquer.Sdl3.Blending;
+namespace Open.CommandAndConquer.Sdl3.Blending;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
-
-internal static partial class SDL3
+public enum BlendOperation
 {
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_ComposeCustomBlendMode))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial BlendMode SDL_ComposeCustomBlendMode(
-        BlendFactor srcColorFactor,
-        BlendFactor dstColorFactor,
-        BlendOperation colorOperation,
-        BlendFactor srcAlphaFactor,
-        BlendFactor dstAlphaFactor,
-        BlendOperation alphaOperation
-    );
+    Add = 1,
+    Subtract,
+    ReverseSubtract,
+    Minimum,
+    Maximum,
 }

--- a/Open.CommandAndConquer.Sdl3/src/Blending/CustomBlendMode.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Blending/CustomBlendMode.cs
@@ -17,22 +17,22 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Open.CommandAndConquer.Sdl3.Blending;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.Blending;
 
-internal static partial class SDL3
+public static class CustomBlendMode
 {
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_ComposeCustomBlendMode))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial BlendMode SDL_ComposeCustomBlendMode(
-        BlendFactor srcColorFactor,
-        BlendFactor dstColorFactor,
-        BlendOperation colorOperation,
-        BlendFactor srcAlphaFactor,
-        BlendFactor dstAlphaFactor,
-        BlendOperation alphaOperation
-    );
+    public static BlendMode Compose(
+        (BlendFactor Source, BlendFactor Destination, BlendOperation Operation) color,
+        (BlendFactor Source, BlendFactor Destination, BlendOperation Operation) alpha
+    ) =>
+        SDL_ComposeCustomBlendMode(
+            color.Source,
+            color.Destination,
+            color.Operation,
+            alpha.Source,
+            alpha.Destination,
+            alpha.Operation
+        );
 }

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_surface.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_surface.cs
@@ -21,6 +21,7 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Blending;
 
 namespace Open.CommandAndConquer.Sdl3.Imports;
 
@@ -336,17 +337,14 @@ internal static partial class SDL3
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_SetSurfaceBlendMode))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_SetSurfaceBlendMode(
-        SDL_Surface surface,
-        SDL_BlendMode blendMode
-    );
+    public static partial bool SDL_SetSurfaceBlendMode(SDL_Surface surface, BlendMode blendMode);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetSurfaceBlendMode))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
     public static partial bool SDL_GetSurfaceBlendMode(
         SDL_Surface surface,
-        out SDL_BlendMode blendMode
+        out BlendMode blendMode
     );
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_SetSurfaceClipRect))]


### PR DESCRIPTION
Introduce `BlendFactor`, `BlendMode`, `BlendOperation`, and `CustomBlendMode` to standardize blending functionality.

Replaced legacy SDL-specific blending types with the new enums across the codebase for improved readability and maintainability.

Updated project version to `0.10.0` to reflect these changes.