### PR TITLE
Add managed geometry types with custom marshalling support

### DIFF
--- a/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
+++ b/Open.CommandAndConquer.Sdl3/Open.CommandAndConquer.Sdl3.csproj
@@ -27,7 +27,7 @@
     
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>0.10.0</Version>
+        <Version>0.11.0</Version>
         <Title>Open.CommandAndConquer.Sdl3</Title>
         <Authors>Open.CommandAndConquer, Victor Matia &lt;vmatir@outlook.com&gt;</Authors>
         <Description>A direct import of the SDL3 library for the Open.CommandAndConquer project.</Description>

--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/FPointMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/FPointMarshaller.cs
@@ -17,25 +17,21 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Geometry;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-internal static partial class SDL3
+[CustomMarshaller(typeof(FPoint), MarshalMode.ElementIn, typeof(ElementIn))]
+internal static class FPointMarshaller
 {
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
+    public static class ElementIn
+    {
+        public static FPoint ConvertToManaged(SDL_FPoint unmanaged) =>
+            new(unmanaged.x, unmanaged.y);
 
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
+        public static SDL_FPoint ConvertToUnmanaged(FPoint managed) =>
+            new() { x = managed.X, y = managed.Y };
+    }
 }

--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/FRectMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/FRectMarshaller.cs
@@ -1,0 +1,75 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Open.CommandAndConquer, Victor Matia <vmatir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the “Software”), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Geometry;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
+
+namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
+
+[CustomMarshaller(typeof(FRect), MarshalMode.Default, typeof(FRectMarshaller))]
+[CustomMarshaller(typeof(FRect), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
+internal static class FRectMarshaller
+{
+    public static SDL_FRect ConvertToUnmanaged(FRect managed) =>
+        new()
+        {
+            x = managed.X,
+            y = managed.Y,
+            w = managed.W,
+            h = managed.H,
+        };
+
+    public static FRect ConvertToManaged(SDL_FRect unmanaged) =>
+        new(unmanaged.x, unmanaged.y, unmanaged.w, unmanaged.y);
+
+    public unsafe ref struct ManagedToUnmanagedIn
+    {
+        private GCHandle _handle;
+
+        public SDL_FRect* ToUnmanaged() => (SDL_FRect*)GCHandle.ToIntPtr(_handle);
+
+        public void FromManaged(FRect? managed)
+        {
+            if (managed is null)
+            {
+                return;
+            }
+
+            SDL_FRect unmanaged = new()
+            {
+                x = managed.X,
+                y = managed.Y,
+                w = managed.W,
+                h = managed.H,
+            };
+
+            _handle = GCHandle.Alloc(unmanaged, GCHandleType.Pinned);
+        }
+
+        public void Free()
+        {
+            if (_handle.IsAllocated)
+            {
+                _handle.Free();
+            }
+        }
+    }
+}

--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/PointMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/PointMarshaller.cs
@@ -17,25 +17,20 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Geometry;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-internal static partial class SDL3
+[CustomMarshaller(typeof(Point), MarshalMode.ElementIn, typeof(ElementIn))]
+internal static class PointMarshaller
 {
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
+    public static class ElementIn
+    {
+        public static Point ConvertToManaged(SDL_Point unmanaged) => new(unmanaged.x, unmanaged.y);
 
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
+        public static SDL_Point ConvertToUnmanaged(Point managed) =>
+            new() { x = managed.X, y = managed.Y };
+    }
 }

--- a/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/RectMarshaller.cs
+++ b/Open.CommandAndConquer.Sdl3/src/CustomMarshalling/RectMarshaller.cs
@@ -1,0 +1,75 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2025 Open.CommandAndConquer, Victor Matia <vmatir@outlook.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the “Software”), to deal in the Software without
+// restriction, including without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Geometry;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
+
+namespace Open.CommandAndConquer.Sdl3.CustomMarshalling;
+
+[CustomMarshaller(typeof(Rect), MarshalMode.Default, typeof(RectMarshaller))]
+[CustomMarshaller(typeof(Rect), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
+internal static class RectMarshaller
+{
+    public static SDL_Rect ConvertToUnmanaged(Rect managed) =>
+        new()
+        {
+            x = managed.X,
+            y = managed.Y,
+            w = managed.W,
+            h = managed.H,
+        };
+
+    public static Rect ConvertToManaged(SDL_Rect unmanaged) =>
+        new(unmanaged.x, unmanaged.y, unmanaged.w, unmanaged.y);
+
+    public unsafe ref struct ManagedToUnmanagedIn
+    {
+        private GCHandle _handle;
+
+        public SDL_Rect* ToUnmanaged() => (SDL_Rect*)GCHandle.ToIntPtr(_handle);
+
+        public void FromManaged(Rect? managed)
+        {
+            if (managed is null)
+            {
+                return;
+            }
+
+            SDL_Rect unmanaged = new()
+            {
+                x = managed.X,
+                y = managed.Y,
+                w = managed.W,
+                h = managed.H,
+            };
+
+            _handle = GCHandle.Alloc(unmanaged, GCHandleType.Pinned);
+        }
+
+        public void Free()
+        {
+            if (_handle.IsAllocated)
+            {
+                _handle.Free();
+            }
+        }
+    }
+}

--- a/Open.CommandAndConquer.Sdl3/src/Geometry/FPoint.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Geometry/FPoint.cs
@@ -17,25 +17,14 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.Geometry;
 
-internal static partial class SDL3
+[NativeMarshalling(typeof(FPointMarshaller))]
+public record FPoint(float X, float Y)
 {
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
+    public bool InRect(FRect rect) =>
+        X >= rect.X && X < rect.X + rect.W && Y >= rect.Y && Y < rect.Y + rect.H;
 }

--- a/Open.CommandAndConquer.Sdl3/src/Geometry/GeometryExtensions.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Geometry/GeometryExtensions.cs
@@ -17,25 +17,21 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using static Open.CommandAndConquer.Sdl3.Imports.SDL3;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.Geometry;
 
-internal static partial class SDL3
+public static class GeometryExtensions
 {
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
+    public static bool TryGetRectEnclosingPoints(
+        this ICollection<Point> points,
+        Rect? clip,
+        out Rect result
+    ) => SDL_GetRectEnclosingPoints(points.ToArray(), points.Count, clip, out result);
 
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
+    public static bool TryGetRectEnclosingPoints(
+        this ICollection<FPoint> points,
+        FRect? clip,
+        out FRect result
+    ) => SDL_GetRectEnclosingPointsFloat(points.ToArray(), points.Count, clip, out result);
 }

--- a/Open.CommandAndConquer.Sdl3/src/Geometry/Point.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Geometry/Point.cs
@@ -17,25 +17,14 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.CustomMarshalling;
 
-namespace Open.CommandAndConquer.Sdl3.Imports;
+namespace Open.CommandAndConquer.Sdl3.Geometry;
 
-internal static partial class SDL3
+[NativeMarshalling(typeof(PointMarshaller))]
+public record Point(int X, int Y)
 {
-    private static uint SDL_FOURCC(char A, char B, char C, char D) =>
-        (uint)((byte)A | (byte)B << 8 | (byte)C << 16 | (byte)D << 24);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_strdup))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial byte* SDL_strdup(byte* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial void SDL_free(void* str);
-
-    [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_free))]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void SDL_free(IntPtr str);
+    public bool InRect(Rect rect) =>
+        X >= rect.X && X < rect.X + rect.W && Y >= rect.Y && Y < rect.Y + rect.H;
 }

--- a/Open.CommandAndConquer.Sdl3/src/Imports/SDL_rect.cs
+++ b/Open.CommandAndConquer.Sdl3/src/Imports/SDL_rect.cs
@@ -20,6 +20,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
+using Open.CommandAndConquer.Sdl3.Geometry;
 
 namespace Open.CommandAndConquer.Sdl3.Imports;
 
@@ -57,185 +58,77 @@ internal static partial class SDL3
         public float h;
     }
 
-    public static void SDL_RectToFRect(in SDL_Rect rect, out SDL_FRect frect)
-    {
-        frect.x = rect.x;
-        frect.y = rect.y;
-        frect.w = rect.w;
-        frect.h = rect.h;
-    }
-
-    public static bool SDL_PointInRect(in SDL_Point p, in SDL_Rect r) =>
-        p.x >= r.x && p.x < r.x + r.w && p.y >= r.y && p.y < r.y + r.h;
-
-    public static bool SDL_RectEmpty(in SDL_Rect r) => r.w <= 0 || r.h <= 0;
-
-    public static bool SDL_RectsEqual(in SDL_Rect a, in SDL_Rect b) =>
-        a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h;
-
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_HasRectIntersection))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_HasRectIntersection(in SDL_Rect A, in SDL_Rect B);
+    public static partial bool SDL_HasRectIntersection(Rect A, Rect B);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectIntersection))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_GetRectIntersection(
-        in SDL_Rect A,
-        in SDL_Rect B,
-        out SDL_Rect result
-    );
+    public static partial bool SDL_GetRectIntersection(Rect A, Rect B, out Rect result);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectUnion))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_GetRectUnion(in SDL_Rect A, in SDL_Rect B, out SDL_Rect result);
+    public static partial bool SDL_GetRectUnion(Rect A, Rect B, out Rect result);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectEnclosingPoints))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    private static unsafe partial bool INTERNAL_SDL_GetRectEnclosingPoints(
+    public static unsafe partial bool SDL_GetRectEnclosingPoints(
         [In]
-        [MarshalUsing(
-            typeof(ArrayMarshaller<SDL_Point, SDL_Point>),
-            CountElementName = nameof(count)
-        )]
-            SDL_Point[] points,
+        [MarshalUsing(typeof(ArrayMarshaller<Point, SDL_Point>), CountElementName = nameof(count))]
+            Point[] points,
         int count,
-        SDL_Rect* clip,
-        out SDL_Rect result
+        Rect? clip,
+        out Rect result
     );
-
-    public static bool SDL_GetRectEnclosingPoints(Span<SDL_Point> points, out SDL_Rect result)
-    {
-        unsafe
-        {
-            return INTERNAL_SDL_GetRectEnclosingPoints(
-                points.ToArray(),
-                points.Length,
-                null,
-                out result
-            );
-        }
-    }
-
-    public static bool SDL_GetRectEnclosingPoints(
-        Span<SDL_Point> points,
-        SDL_Rect clip,
-        out SDL_Rect result
-    )
-    {
-        unsafe
-        {
-            return INTERNAL_SDL_GetRectEnclosingPoints(
-                points.ToArray(),
-                points.Length,
-                &clip,
-                out result
-            );
-        }
-    }
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectAndLineIntersection))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
     public static partial bool SDL_GetRectAndLineIntersection(
-        in SDL_Rect rect,
+        Rect rect,
         ref int X1,
         ref int Y1,
         ref int X2,
         ref int Y2
     );
 
-    public static bool SDL_PointInRectFloat(in SDL_FPoint p, in SDL_FRect r) =>
-        p.x >= r.x && p.x < r.x + r.w && p.y >= r.y && p.y < r.y + r.h;
-
-    public static bool SDL_RectEmptyFloat(in SDL_FRect r) => r.w <= 0 || r.h <= 0;
-
-    public static bool SDL_RectsEqualEpsilon(in SDL_FRect a, in SDL_FRect b, float epsilon) =>
-        SDL_fabsf(a.x - b.x) <= epsilon
-        && SDL_fabsf(a.y - b.y) <= epsilon
-        && SDL_fabsf(a.w - b.w) <= epsilon
-        && SDL_fabsf(a.h - b.h) <= epsilon;
-
-    public static bool SDL_RectsEqualFloat(in SDL_FRect a, in SDL_FRect b) =>
-        SDL_RectsEqualEpsilon(a, b, SDL_FLT_EPSILON);
-
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_HasRectIntersectionFloat))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_HasRectIntersectionFloat(in SDL_FRect A, in SDL_FRect B);
+    public static partial bool SDL_HasRectIntersectionFloat(FRect A, FRect B);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectIntersectionFloat))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_GetRectIntersectionFloat(
-        in SDL_FRect A,
-        in SDL_FRect B,
-        out SDL_FRect result
-    );
+    public static partial bool SDL_GetRectIntersectionFloat(FRect A, FRect B, out FRect result);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectUnionFloat))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool SDL_GetRectUnionFloat(
-        in SDL_FRect A,
-        in SDL_FRect B,
-        out SDL_FRect result
-    );
+    public static partial bool SDL_GetRectUnionFloat(FRect A, FRect B, out FRect result);
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectEnclosingPointsFloat))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    private static unsafe partial bool INTERNAL_SDL_GetRectEnclosingPointsFloat(
-        [In] [MarshalUsing(typeof(ArrayMarshaller<SDL_FPoint, SDL_FPoint>))] SDL_FPoint[] points,
+    public static unsafe partial bool SDL_GetRectEnclosingPointsFloat(
+        [In] [MarshalUsing(typeof(ArrayMarshaller<FPoint, SDL_FPoint>))] FPoint[] points,
         int count,
-        SDL_FRect* clip,
-        out SDL_FRect result
+        FRect? clip,
+        out FRect result
     );
-
-    public static bool SDL_GetRectEnclosingPointsFloat(
-        Span<SDL_FPoint> points,
-        out SDL_FRect result
-    )
-    {
-        unsafe
-        {
-            return INTERNAL_SDL_GetRectEnclosingPointsFloat(
-                points.ToArray(),
-                points.Length,
-                null,
-                out result
-            );
-        }
-    }
-
-    public static bool SDL_GetRectEnclosingPointsFloat(
-        Span<SDL_FPoint> points,
-        SDL_FRect clip,
-        out SDL_FRect result
-    )
-    {
-        unsafe
-        {
-            return INTERNAL_SDL_GetRectEnclosingPointsFloat(
-                points.ToArray(),
-                points.Length,
-                &clip,
-                out result
-            );
-        }
-    }
 
     [LibraryImport(nameof(SDL3), EntryPoint = nameof(SDL_GetRectAndLineIntersectionFloat))]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
     public static partial bool SDL_GetRectAndLineIntersectionFloat(
-        in SDL_FRect rect,
-        ref int X1,
-        ref int Y1,
-        ref int X2,
-        ref int Y2
+        FRect rect,
+        ref float X1,
+        ref float Y1,
+        ref float X2,
+        ref float Y2
     );
 }


### PR DESCRIPTION
Introduced `Point`, `FPoint`, `Rect`, and `FRect` types with support for custom marshalling.

Extensions for geometry operations and updates to `SDL3` imports for type integration were included.

Version bumped to 0.11.0 to reflect the new functionality.